### PR TITLE
fix memory write mask behavior

### DIFF
--- a/src/main/scala/MemBlackBoxer/MemManager/MemConfig.scala
+++ b/src/main/scala/MemBlackBoxer/MemManager/MemConfig.scala
@@ -9,6 +9,7 @@ case class MemConfig
   dataWidth: Int,
   depth: Int,
   vendor: MemVendor,
+  maskBitWidth: Int = 0, // bit width of write mask
   withBist: Boolean = true,
   withScan: Boolean = false,
   withPowerGate: Boolean = false,
@@ -17,5 +18,17 @@ case class MemConfig
   val bytePerWord = (dataWidth+7)/8
   val size = bytePerWord * (1 << addrWidth)
   var name = vendor.prefixName + "_wc" + depth.toString + "_dw" + dataWidth
-  def genMask: Bits = Bits(dataWidth bit)
+  def bitPerMask = if(maskBitWidth == 0) 0 else math.ceil(dataWidth.toDouble / maskBitWidth).toInt
+  val noMask : Boolean = maskBitWidth == 0
+  val nofMask = if(maskBitWidth == 0) 0 else math.ceil(dataWidth.toDouble / bitPerMask).toInt
+
+  def maskName: String = bitPerMask match {
+    case 16 => "wordMask" // todo may check this mask is half word or word mask (currently copy from jijingg)
+    case  8 => "ByteMask"
+    case  1 => "bitMask"
+    case  0 => "noMask"
+    case  _ => SpinalError("Undefined write mask type")
+  }
+
+  def genMask: Bits = Bits(maskBitWidth bit)
 }

--- a/src/main/scala/MemBlackBoxer/MemManager/MemPorts.scala
+++ b/src/main/scala/MemBlackBoxer/MemManager/MemPorts.scala
@@ -9,12 +9,12 @@ class MemPorts extends Bundle
 
 case class AddrCtrlPorts(mc: MemConfig) extends MemPorts with IMasterSlave {
   val memoryEnable = Bool()
-  val mask = mc.genMask
+  val mask = if (mc.maskBitWidth != 0) mc.genMask else null
   val address = UInt(mc.addrWidth bit)
 
   override def asMaster(): Unit = {
     in(memoryEnable, mask, address)
-    in(memoryEnable, address)
+//    in(memoryEnable, address)
   }
 }
 

--- a/src/main/scala/MemBlackBoxer/MemManager/MemWrapper.scala
+++ b/src/main/scala/MemBlackBoxer/MemManager/MemWrapper.scala
@@ -29,14 +29,14 @@ case class Ram1rw(mc: MemConfig) extends MemWrapper(mc) {
 }
 
 /**
- * Memory wrapper type for dual port SRAM
+ * Memory wrapper type for two port SRAM
  * @param mc - memory config, including the data width, address width and memory vendor etc.
  */
 case class Ram1r1w(mc: MemConfig) extends MemWrapper(mc) {
   val io = new Bundle {
     val clka, clkb = in Bool()
     val apa = in(AddrCtrlPorts(mc))
-    val apb = in(AddrCtrlPorts(mc))
+    val apb = in(AddrCtrlPorts(mc)) // todo Ram1r1w doesnt need the mask of apb. May change this definition latter.
     val dp = master(DataPorts(mc))
 //    val bista = master(BistPorts(mc))
 //    val bistb = master(BistPorts(mc))
@@ -50,7 +50,7 @@ case class Ram1r1w(mc: MemConfig) extends MemWrapper(mc) {
 }
 
 /**
- * Memory wrapper type for two port SRAM
+ * Memory wrapper type for dual port SRAM
  * @param mc - memory config, including the data width, address width and memory vendor etc.
  */
 case class Ram2rw(mc: MemConfig) extends MemWrapper(mc) {
@@ -63,12 +63,12 @@ case class Ram2rw(mc: MemConfig) extends MemWrapper(mc) {
     val dpb = master(DataPorts(mc))
 //    val bistb = master(BistPorts(mc))
   }
-  override val ram = mc.vendor.build(this)
   val cda = ClockDomain.internal("cda", withReset = false)
   val cdb = ClockDomain.internal("cdb", withReset = false)
   cda.clock := io.clka
   cdb.clock := io.clkb
   noIoPrefix()
+  override val ram = mc.vendor.build(this)
 }
 
 /**

--- a/src/main/scala/MemBlackBoxer/Vendor/Huali.scala
+++ b/src/main/scala/MemBlackBoxer/Vendor/Huali.scala
@@ -31,7 +31,7 @@ object Huali extends MemVendor {
       val ADRA, ADRB = in UInt (wrap.mc.addrWidth bit)
       val DA = in Bits (wrap.mc.dataWidth bit)
       val QB = out Bits (wrap.mc.dataWidth bit)
-      val WEMA, WEMB = in Bits (wrap.mc.dataWidth bit)
+      val WEMA = if (wrap.mc.noMask) null else in Bits (wrap.mc.dataWidth bit) // 1r1w may only have one Write mask.
       val WEA, MEA, MEB, TEST1A, TEST1B, RMEA, RMEB, LS = in Bool()
       val RMA, RMB = in Bits (4 bit)
     }
@@ -48,10 +48,11 @@ object Huali extends MemVendor {
       this.io.ADRB <> wrap.io.apb.address
       this.io.DA <> wrap.io.dp.writeData
       this.io.QB <> wrap.io.dp.readData
-      this.io.WEMA <> wrap.io.apa.mask
-      this.io.WEMB <> wrap.io.apb.mask
       this.io.WEA <> wrap.io.dp.writeEnable
       this.io.MEA <> wrap.io.apa.memoryEnable
+      if(!wrap.mc.noMask) {
+        this.io.WEMA <> Vec(wrap.io.apa.mask.subdivideIn(1 bit).map(_.asSInt.resize(wrap.mc.bitPerMask).asBits)).asBits.resized
+      }
       this.io.MEB <> wrap.io.apb.memoryEnable
       this.io.TEST1A := False
       this.io.RMEA := False
@@ -73,7 +74,7 @@ object Huali extends MemVendor {
       val ADR = in UInt (wrap.mc.addrWidth bit)
       val D = in Bits (wrap.mc.dataWidth bit)
       val Q = out Bits (wrap.mc.dataWidth bit)
-      val WEM = in Bits (wrap.mc.dataWidth bit)
+      val WEM = if (wrap.mc.noMask) null else in Bits (wrap.mc.dataWidth bit)
       val WE, ME, TEST1, RME, LS = in Bool()
       val RM = in Bits (4 bit)
     }
@@ -87,7 +88,9 @@ object Huali extends MemVendor {
       this.io.ADR <> wrap.io.ap.address
       this.io.D <> wrap.io.dp.writeData
       this.io.Q <> wrap.io.dp.readData
-      this.io.WEM <> wrap.io.ap.mask
+      if(!wrap.mc.noMask) {
+        this.io.WEM <> Vec(wrap.io.ap.mask.subdivideIn(1 bit).map(_.asSInt.resize(wrap.mc.bitPerMask).asBits)).asBits.resized
+      }
       this.io.WE <> wrap.io.dp.writeEnable
       this.io.ME <> wrap.io.ap.memoryEnable
       this.io.TEST1 := False
@@ -108,7 +111,8 @@ object Huali extends MemVendor {
       val ADRA, ADRB = in UInt (wrap.mc.addrWidth bit)
       val DA, DB = in Bits (wrap.mc.dataWidth bit)
       val QA, QB = out Bits (wrap.mc.dataWidth bit)
-      val WEMA, WEMB = in Bits (wrap.mc.dataWidth bit)
+      val WEMA = if (wrap.mc.noMask) null else in Bits (wrap.mc.dataWidth bit)
+      val WEMB = if (wrap.mc.noMask) null else in Bits (wrap.mc.dataWidth bit)
       val WEA, WEB, MEA, MEB, TEST1A, TEST1B, RMEA, RMEB, LS = in Bool()
       val RMA, RMB = in Bits (4 bit)
     }
@@ -130,9 +134,11 @@ object Huali extends MemVendor {
       //    if(wrap.mc.needMask){
       //      val maska = if (wrap.mc.needMask) wrap.io.apa.mask else B(wrap.mc.dataWidth bit, default -> true)
       //      val maskb = if (wrap.mc.needMask) wrap.io.apb.mask else B(wrap.mc.dataWidth bit, default -> true)
-      this.io.WEMA <> wrap.io.apa.mask
-      this.io.WEMB <> wrap.io.apb.mask
       //    }
+      if(!wrap.mc.noMask) {
+        this.io.WEMA <> Vec(wrap.io.apa.mask.subdivideIn(1 bit).map(_.asSInt.resize(wrap.mc.bitPerMask).asBits)).asBits.resized
+        this.io.WEMB <> Vec(wrap.io.apb.mask.subdivideIn(1 bit).map(_.asSInt.resize(wrap.mc.bitPerMask).asBits)).asBits.resized
+      }
       this.io.WEA <> wrap.io.dpa.writeEnable
       this.io.WEB <> wrap.io.dpb.writeEnable
       this.io.MEA <> wrap.io.apa.memoryEnable


### PR DESCRIPTION
Change the behavior of the memory write mask. 

**Feature**:
* The bit width of the mask in the `MemWrapper` is based on the mask declared in writing behavior. 
* The bit width of the mask in the `Blackbox` is based on the vendor.
* Each `MemVendor` should carefully connect the wire of the mask.
* DualPort SRAM only supports the following situation:
  * PortA and PortB all claim the Mask and the bit width are the same.
  * Only one of the PortA and PortB claims the Mask and leaves the other one as null. (In this situation, the mask of the other Port is set to true as default)